### PR TITLE
correct way to select random image

### DIFF
--- a/lib/avatar-generator.js
+++ b/lib/avatar-generator.js
@@ -48,12 +48,12 @@ function Generator(settings) {
 
         var parts = [],
             partNumber = 0,
-            keySeed = seed(key)(),
+            rand = seed(key),
             current = variants[discriminator];
 
         settings.order.forEach(function (partName) {
             if (current.hasOwnProperty(partName)) {
-                partNumber = ~~(keySeed * current[partName]) + 1;
+                partNumber = ~~(rand() * current[partName]) + 1;
                 parts.push(path.join(settings.images, discriminator, partName + partNumber + '.png'));
             }
         });


### PR DESCRIPTION
On original source, a following script shows 60. it is not expected value.

```
#!/bin/sh

mkdir tmp

i=0
while ((i < 100)); do
  node cli.js --id $i > tmp/$i.jpg
  md5sum < tmp/$i.jpg
  ((i = i + 1))
done | sort | uniq -c | wc -l
```

The fixed source in this request, this script shows 91. it means that is more randomized.

Another example:

```
var seed = require('seed-random');

ary = []
ary.push(5);
ary.push(10);
ary.push(20);

for (var i = 0; i < 10000; i++) {
  var keySeed = seed(i)();
  result = []
  for (j = 0; j < ary.length; j++) {
    result.push(~~(keySeed * ary[j]) + 1);
  }
  console.log(result.join(","));
}
```

It is expected that 1000(= 5 * 10 * 20) patterns are generated, but:

```
node test.js | sort | uniq -c | wc -l
# => 20
```

Fixed one

```
var seed = require('seed-random');

ary = []
ary.push(5);
ary.push(10);
ary.push(20);

for (var i = 0; i < 10000; i++) {
  var rand = seed(i)
  result = []
  for (j = 0; j < ary.length; j++) {
    var keySeed = rand();
    result.push(~~(keySeed * ary[j]) + 1);
  }
  console.log(result.join(","));
}
```

```
node test2.js | sort | uniq -c | wc -l
# => 1000
```