### PR TITLE
Fix a bug caused by hidden files in the img folder

### DIFF
--- a/lib/avatar-generator.js
+++ b/lib/avatar-generator.js
@@ -22,8 +22,8 @@ function Generator(settings) {
     //List all images available
     var variants = {};
     fs.readdirSync(settings.images).forEach(function (discriminator) {
-        // Skip .DS_Store files on Mac and thumbs.db/desktop.ini files on Windows
-        if([".DS_Store", "desktop.ini", "thumbs.db"].indexOf(discriminator) !== -1) {
+        // Some OSes place hidden files, so make sure it's actually a directory
+        if(!fs.statSync(path.join(settings.images, discriminator)).isDirectory()) {
             return;
         }
 

--- a/lib/avatar-generator.js
+++ b/lib/avatar-generator.js
@@ -22,6 +22,11 @@ function Generator(settings) {
     //List all images available
     var variants = {};
     fs.readdirSync(settings.images).forEach(function (discriminator) {
+        // Skip .DS_Store files on Mac and thumbs.db/desktop.ini files on Windows
+        if([".DS_Store", "desktop.ini", "thumbs.db"].indexOf(discriminator) !== -1) {
+            return;
+        }
+
         var current = variants[discriminator] = {};
         fs.readdirSync(path.join(settings.images, discriminator)).forEach(function (file) {
             var match = /(.*?)(\d+)\.png/.exec(file);


### PR DESCRIPTION
MacOS places .DS_Store files in some folders, and this caused the
program to crash. Windows also has some hidden files. This commit solves
the problem by skipping files named ".DS_Store", "thumbs.db", or
"desktop.ini" in the img folder.